### PR TITLE
To make it easier to scan files (Win 10 tested)

### DIFF
--- a/PickleDrop.bat
+++ b/PickleDrop.bat
@@ -1,0 +1,5 @@
+@ECHO OFF
+
+python scan_pickle.py --preset stable_diffusion_v1 --in %~1
+
+cmd /K


### PR DESCRIPTION
I suggest adding a .bat file to make it easier to scan files, all you need to do is drop the file onto PickleDrop.bat and it will begin the scan and then leave the command window open for you to read. It like so much else doesn't tolerate spaces, but as long as the files have a _ or - instead of a space (Example_Here_V1.ckpt)

It sure saves a bunch of hassle and the reason I'm writing python and not python3 is cause python3 doesn't work on my computer